### PR TITLE
Handle nil values correctly

### DIFF
--- a/AppSettings.xcodeproj/project.pbxproj
+++ b/AppSettings.xcodeproj/project.pbxproj
@@ -10,14 +10,14 @@
 		8E01E9FD1854760800C9A70E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E01E9FC1854760800C9A70E /* Foundation.framework */; };
 		8E01EA021854760800C9A70E /* AppSettings.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8E01EA011854760800C9A70E /* AppSettings.h */; };
 		8E01EA041854760800C9A70E /* AppSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E01EA031854760800C9A70E /* AppSettings.m */; };
-		8E01EA0B1854760800C9A70E /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E01EA0A1854760800C9A70E /* XCTest.framework */; };
 		8E01EA0C1854760800C9A70E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E01E9FC1854760800C9A70E /* Foundation.framework */; };
-		8E01EA0E1854760800C9A70E /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E01EA0D1854760800C9A70E /* UIKit.framework */; };
 		8E01EA111854760800C9A70E /* libAppSettings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E01E9F91854760800C9A70E /* libAppSettings.a */; };
 		8E01EA171854760800C9A70E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8E01EA151854760800C9A70E /* InfoPlist.strings */; };
 		8E01EA191854760800C9A70E /* AppSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E01EA181854760800C9A70E /* AppSettingsTests.m */; };
 		8E01EA241854771600C9A70E /* MySettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E01EA231854771600C9A70E /* MySettings.m */; };
 		8E01EA271854835B00C9A70E /* MyNestedSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E01EA261854835B00C9A70E /* MyNestedSettings.m */; };
+		A4D79C8E2019BBE600D37F95 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4D79C8D2019BBE500D37F95 /* XCTest.framework */; };
+		A4D79C902019BBEC00D37F95 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4D79C8F2019BBEC00D37F95 /* UIKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,8 +50,6 @@
 		8E01EA011854760800C9A70E /* AppSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppSettings.h; sourceTree = "<group>"; };
 		8E01EA031854760800C9A70E /* AppSettings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppSettings.m; sourceTree = "<group>"; };
 		8E01EA091854760800C9A70E /* AppSettingsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppSettingsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8E01EA0A1854760800C9A70E /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		8E01EA0D1854760800C9A70E /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		8E01EA141854760800C9A70E /* AppSettingsTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "AppSettingsTests-Info.plist"; sourceTree = "<group>"; };
 		8E01EA161854760800C9A70E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8E01EA181854760800C9A70E /* AppSettingsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppSettingsTests.m; sourceTree = "<group>"; };
@@ -59,6 +57,8 @@
 		8E01EA231854771600C9A70E /* MySettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MySettings.m; sourceTree = "<group>"; };
 		8E01EA251854835B00C9A70E /* MyNestedSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MyNestedSettings.h; sourceTree = "<group>"; };
 		8E01EA261854835B00C9A70E /* MyNestedSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MyNestedSettings.m; sourceTree = "<group>"; };
+		A4D79C8D2019BBE500D37F95 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		A4D79C8F2019BBEC00D37F95 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,9 +74,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A4D79C902019BBEC00D37F95 /* UIKit.framework in Frameworks */,
+				A4D79C8E2019BBE600D37F95 /* XCTest.framework in Frameworks */,
 				8E01EA111854760800C9A70E /* libAppSettings.a in Frameworks */,
-				8E01EA0B1854760800C9A70E /* XCTest.framework in Frameworks */,
-				8E01EA0E1854760800C9A70E /* UIKit.framework in Frameworks */,
 				8E01EA0C1854760800C9A70E /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -106,9 +106,9 @@
 		8E01E9FB1854760800C9A70E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A4D79C8F2019BBEC00D37F95 /* UIKit.framework */,
+				A4D79C8D2019BBE500D37F95 /* XCTest.framework */,
 				8E01E9FC1854760800C9A70E /* Foundation.framework */,
-				8E01EA0A1854760800C9A70E /* XCTest.framework */,
-				8E01EA0D1854760800C9A70E /* UIKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -197,7 +197,7 @@
 		8E01E9F11854760800C9A70E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0920;
 				ORGANIZATIONNAME = Sigmapoint;
 			};
 			buildConfigurationList = 8E01E9F41854760800C9A70E /* Build configuration list for PBXProject "AppSettings" */;
@@ -274,22 +274,33 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -302,7 +313,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -312,29 +323,39 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -367,7 +388,6 @@
 		8E01EA201854760800C9A70E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -380,6 +400,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "AppSettingsTests/AppSettingsTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "pl.sigmapoint.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -388,7 +409,6 @@
 		8E01EA211854760800C9A70E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -397,6 +417,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AppSettings/AppSettings-Prefix.pch";
 				INFOPLIST_FILE = "AppSettingsTests/AppSettingsTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "pl.sigmapoint.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -421,6 +442,7 @@
 				8E01EA1E1854760800C9A70E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8E01EA1F1854760800C9A70E /* Build configuration list for PBXNativeTarget "AppSettingsTests" */ = {
 			isa = XCConfigurationList;
@@ -429,6 +451,7 @@
 				8E01EA211854760800C9A70E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/AppSettings/AppSettings.m
+++ b/AppSettings/AppSettings.m
@@ -42,7 +42,18 @@
 
 - (NSDictionary*)dictionaryOfPropertiesAndValues
 {
-    return [self dictionaryWithValuesForKeys:[self propertiesNames]];
+    NSDictionary *result = [self dictionaryWithValuesForKeys:[self propertiesNames]];
+    if ([[result allValues] containsObject:[NSNull null]]) {
+      NSMutableDictionary *mutableResult = [NSMutableDictionary dictionaryWithDictionary:result];
+      for (NSString * key in mutableResult.allKeys) {
+        id val = [mutableResult objectForKey:key];
+        if ([val isKindOfClass:[NSNull class]]) {
+          [mutableResult removeObjectForKey:key];
+        }
+      }
+      result = [NSDictionary dictionaryWithDictionary:mutableResult];
+    }
+    return result;
 }
 
 #pragma mark - NSUserDefaults save & load

--- a/AppSettingsTests/AppSettingsTests-Info.plist
+++ b/AppSettingsTests/AppSettingsTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>pl.sigmapoint.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/AppSettingsTests/AppSettingsTests.m
+++ b/AppSettingsTests/AppSettingsTests.m
@@ -33,7 +33,7 @@
 - (void)testPropertiesCount
 {
     NSArray *d = [_mySettings propertiesNames];
-    XCTAssertEqualObjects(@(d.count), @6, @"");
+    XCTAssertEqualObjects(@(d.count), @7, @"");
 }
 
 - (void)testSerialization
@@ -90,6 +90,13 @@
     XCTAssertNotNil(ms, @"");
     
     NSLog(@"loaded settings from custom key: %@", [ms dictionaryOfPropertiesAndValues]);
+}
+
+- (void)testEmptyData {
+  _mySettings.exampleData = nil;
+  [_mySettings saveUnderKey:@"testEmptyData"];
+  MySettings *ms = [MySettings loadFromKey:@"testEmptyData"];
+  XCTAssertNotNil(ms, @"");
 }
 
 @end

--- a/AppSettingsTests/AppSettingsTests.m
+++ b/AppSettingsTests/AppSettingsTests.m
@@ -99,4 +99,20 @@
   XCTAssertNotNil(ms, @"");
 }
 
+- (void)testEmptyProperties {
+  _mySettings.exampleData = nil;
+  _mySettings.exampleDate = nil;
+  _mySettings.exampleNumber = nil;
+  _mySettings.exampleString = nil;
+  NSString *key = @"testEmptyProperties";
+  [_mySettings saveUnderKey:key];
+  MySettings *ms = [MySettings loadFromKey:key];
+  XCTAssertNotNil(ms, @"");
+  XCTAssertNil(ms.exampleData);
+  XCTAssertNil(ms.exampleDate);
+  XCTAssertNil(ms.exampleNumber);
+  XCTAssertNil(ms.exampleString);
+}
+
+
 @end

--- a/AppSettingsTests/MySettings.h
+++ b/AppSettingsTests/MySettings.h
@@ -16,6 +16,7 @@
 @property (nonatomic, strong) NSNumber *exampleNumber;
 @property (nonatomic, assign) int exampleInt;
 @property (nonatomic, assign) BOOL exampleBool;
+@property (nonatomic, strong) NSData *exampleData; 
 
 @property (nonatomic, strong) MyNestedSettings *myNestedSettings;
 

--- a/AppSettingsTests/MySettings.m
+++ b/AppSettingsTests/MySettings.m
@@ -17,6 +17,7 @@
     _exampleNumber = @123;
     _exampleInt = 456;
     _exampleBool = YES;
+    _exampleData = [@"test data" dataUsingEncoding:NSUTF8StringEncoding];
     
     _myNestedSettings = [[MyNestedSettings alloc] init];
     [_myNestedSettings loadExampleValue];


### PR DESCRIPTION
I found that AppSettings was crashing when trying to serialise NIL values. I've added NSNull filtering to avoid this. 
Also, project settings upgraded to be compatible with latest xCode. 